### PR TITLE
Install tk and tk-dev to fix _tkagg import error

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install -y \
         supervisor \
         cmake \
         libboost-all-dev \
+        tk \
+        tk-dev \
         python-tk \
         libsdl2-dev \
         xvfb

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install -y \
         supervisor \
         cmake \
         libboost-all-dev \
+        tk \
+        tk-dev \
         python-tk \
         libsdl2-dev \
         xvfb


### PR DESCRIPTION
matplotlib without tk and tk-dev package throws out `ImportError (cannot import name _tkagg)`.

Ref: http://stackoverflow.com/questions/13110403/matplotlib-backend-missing-modules-with-underscore
